### PR TITLE
Add simple drake publisher/subscriber demos

### DIFF
--- a/ros_demo/README
+++ b/ros_demo/README
@@ -1,0 +1,11 @@
+A simple demo interface between ROS 1 and Drake.
+
+Usage:
+    - start ROS `$ roscore`
+    - Test publishing a message from a Drake system to ROS
+        - `$ ./drake_publisher.py` sends a `String` message with the current time.
+        - You should be able to view it with `$ rostopic echo /ros_to_drake`
+    - Test subscribing to a ROS message from inside a Drake system
+        - run `$ ./ros_publisher.py` to publish to `/ros_to_drake`
+        - run `$ ./drake_subscriber.py` to subscribe to that topic
+

--- a/ros_demo/drake_publisher.py
+++ b/ros_demo/drake_publisher.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+##
+#
+# A simple Drake system that publishes a message to a ROS topic.
+#
+##
+
+import rospy
+from std_msgs.msg import String
+
+from pydrake.all import LeafSystem, Simulator, BasicVector, DiagramBuilder
+
+
+class RosPublisher(LeafSystem):
+    """
+    A Drake LeafSystem that publishes to a ROS topic at a fixed frequency.
+    """
+    def __init__(self):
+        LeafSystem.__init__(self)
+
+        # Declare a ROS publisher
+        topic = "/ros_to_drake"
+        self.ros_publisher = rospy.Publisher(topic, String, queue_size=10)
+
+        # Declare a Drake publishing event that runs at 10 Hz
+        self.DeclarePeriodicPublishEvent(
+            period_sec=0.1,
+            offset_sec=0.0,
+            publish=self.Publish)
+
+    def Publish(self, context):
+        """
+        Publishes a message to the ROS topic.
+        """
+        msg = f"The current Drake time is: {context.get_time()}" 
+        self.ros_publisher.publish(msg)
+
+
+if __name__=="__main__":
+    # Set up the ROS node
+    rospy.init_node("drake_publisher")
+
+    # Set up the Drake system diagram
+    builder = DiagramBuilder()
+    builder.AddSystem(RosPublisher())
+    diagram = builder.Build()
+
+    # Run the Drake diagram with a Simulator object
+    simulator = Simulator(diagram)
+    simulator.set_target_realtime_rate(1.0)
+    simulator.Initialize()
+    simulator.AdvanceTo(10.0)

--- a/ros_demo/drake_subscriber.py
+++ b/ros_demo/drake_subscriber.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+##
+#
+# A simple Drake system that reads a message from a ROS topic.
+#
+##
+
+import rospy
+from std_msgs.msg import Float64
+
+from pydrake.all import LeafSystem, Simulator, BasicVector, DiagramBuilder
+
+
+class RosSubscriber(LeafSystem):
+    """
+    A Drake LeafSystem that subscribes to a ROS topic.
+    """
+    def __init__(self):
+        LeafSystem.__init__(self)
+
+        # Declare a ROS subscriber
+        topic = "/ros_to_drake"
+        self.ros_subscriber = rospy.Subscriber(topic, Float64, self.callback)
+
+        # Store the latest message from ROS
+        self.latest_message = None
+
+        # Declare a periodic publish event that runs at 10 Hz. In this case
+        # this event has nothing to do with publishing, but we use it to
+        # just print out the latest message from ROS. In practice this would be
+        # replaced with output ports or something more interesting. 
+        self.DeclarePeriodicPublishEvent(
+            period_sec=0.1,
+            offset_sec=0.0,
+            publish=self.PrintMessage)
+
+        # Spin for a bit to let the subscriber connect
+        rospy.sleep(1)
+
+    def PrintMessage(self, context):
+        """
+        Prints the latest message from ROS.
+        """
+        print(f"Latest message from ROS: {self.latest_message}")
+
+    def callback(self, msg):
+        """
+        Callback function for the ROS subscriber.
+        """
+        self.latest_message = msg.data
+
+
+if __name__=="__main__":
+    # Set up the ROS node
+    rospy.init_node("drake_subscriber")
+
+    # Set up the Drake system diagram
+    builder = DiagramBuilder()
+    builder.AddSystem(RosSubscriber())
+    diagram = builder.Build()
+
+    # Run the Drake diagram with a Simulator object
+    simulator = Simulator(diagram)
+    simulator.set_target_realtime_rate(1.0)
+    simulator.Initialize()
+    simulator.AdvanceTo(10.0)

--- a/ros_demo/ros_publisher.py
+++ b/ros_demo/ros_publisher.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+##
+#
+# A simple ROS publisher node that publishes a dummy message
+# with the current time. 
+#
+##
+
+import rospy
+from std_msgs.msg import Float64
+
+if __name__=="__main__":
+    topic = "/ros_to_drake"
+
+    rospy.init_node("ros_publisher")
+    pub = rospy.Publisher(topic, Float64, queue_size=10)
+
+    rate = rospy.Rate(100)
+    start_time = rospy.get_time()
+
+    while not rospy.is_shutdown():
+        msg = Float64()
+        msg.data = rospy.get_time() - start_time
+        pub.publish(msg)
+        rate.sleep()


### PR DESCRIPTION
Adds some simple demos of a Drake-ROS interface. The subscriber side you had working already, I believe. The only new thing is the publisher side (which is simpler anyway).

Let me know if you'd like a more complicated example with a subscriber and a publisher operating in the same system diagram. 